### PR TITLE
invalid import for fluent_conv

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "build": "npm run clean && npm run build:cjs && npm run build:es && npm run build:umd && npm run copy",
     "build-win": "npm run clean && npm run build:cjs && npm run build:es-win && npm run build:umd && npm run copy-win",
     "preversion": "npm run test && npm run build && git push",
-    "postversion": "git push && git push --tags",
-    "prepare": "npm run build"
+    "postversion": "git push && git push --tags"
   },
   "author": "Jan Mühlemann <jan.muehlemann@gmail.com> (https://github.com/jamuhl)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "build": "npm run clean && npm run build:cjs && npm run build:es && npm run build:umd && npm run copy",
     "build-win": "npm run clean && npm run build:cjs && npm run build:es-win && npm run build:umd && npm run copy-win",
     "preversion": "npm run test && npm run build && git push",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
+    "prepare": "npm run build"
   },
   "author": "Jan Mühlemann <jan.muehlemann@gmail.com> (https://github.com/jamuhl)",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import * as utils from './utils.js';
 import ajax from './ajax.js';
 
-import ftl2js from 'fluent_conv/lib/ftl2js';
+import ftl2js from 'fluent_conv/esm/ftl2js';
 
 function getDefaults() {
   return {


### PR DESCRIPTION
I fixed it, I based this on the [``package.json that is defined by them``](https://github.com/locize/fluent_conv/blob/master/package.json#L34). This happened to me because ``vite`` returns an error when trying to bundle everything

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)